### PR TITLE
Add checkout action to cf job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,5 +43,6 @@ jobs:
             CF_PASSWORD: '${{ secrets.cf_password }}'
             CF_TARGET_ORG: mith-org
             CF_TARGET_SPACE: development
+            GITHUB_REPOSITORY: '${{ secrets.github_repo }}'
           with:
             args: 'echo "$GITHUB_REPOSITORY" & push /home/runner/work/mith_calculator/mith_calculator'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,6 +36,7 @@ jobs:
   cf:
      runs-on: ubuntu-latest
      steps:
+        - uses: actions/checkout@v1
         - uses: d3sandoval/cloud-foundry-action@1.1.1
           env:
             CF_USERNAME: ${{ secrets.cf_username }}


### PR DESCRIPTION
In response to #1, it looks like the job is failing because there's nothing to push, since your job hasn't done a [checkout](https://github.com/actions/checkout):

> This action checks out your repository to `$GITHUB_WORKSPACE`, so that your workflow can access the contents of your repository.
> 
> By default, this is equivalent to running `git fetch` and `git checkout $GITHUB_SHA`, so that you'll always have your repo contents at the version that triggered the workflow.
> See [here](https://help.github.com/en/articles/events-that-trigger-workflows) to learn what `$GITHUB_SHA` is for different kinds of events.